### PR TITLE
Bug Fix: Empty "players" array was not supported

### DIFF
--- a/kp2rig/src/KpJsonImporter.hpp
+++ b/kp2rig/src/KpJsonImporter.hpp
@@ -29,6 +29,7 @@ public:
 private:
    void OpenJson( std::string jsonFilename );
    void UpdateCurrentPlayerIt ();
+   void UpdateCurrentFrameIt ();
    
    nlohmann::json _json;
    nlohmann::json::iterator _currentFrameIt;


### PR DESCRIPTION
Previously, I was de-referencing the _currentPlayerItr without checking if it is valid. In the case that "players" array was empty in a frame, we would get a runtime error. The fix is to check validity of this pointer before using it. 

Also moved updating _currentFrameItr code into a separate function. 

